### PR TITLE
Small fixes and quality improvement changes.

### DIFF
--- a/fairseq_cli/validate.py
+++ b/fairseq_cli/validate.py
@@ -155,6 +155,7 @@ def main(cfg: DictConfig, override_args=None):
                 subset=subset,
                 logits_shape=logits_shape,
                 targets_shape=targets_shape,
+                directory=cfg.common_eval.results_path,
             )
 
         progress = progress_bar.progress_bar(

--- a/fairseq_cli/validate.py
+++ b/fairseq_cli/validate.py
@@ -115,7 +115,7 @@ def main(cfg: DictConfig, override_args=None):
     for subset in cfg.dataset.valid_subset.split(","):
         subset = subset.strip()
         try:
-            task.load_dataset(subset, combine=False, epoch=1, task_cfg=cfg.task)
+            task.load_dataset(subset, combine=False, epoch=1, task_cfg=cfg.task, shuffle=False)
             dataset = task.dataset(subset)
         except KeyError:
             raise Exception("Cannot find dataset: " + subset)

--- a/fairseq_signals/optim/adam.py
+++ b/fairseq_signals/optim/adam.py
@@ -44,7 +44,11 @@ class Adam(Optimizer):
     def __init__(self, cfg: AdamConfig, params):
         super().__init__(cfg)
         self._optimizer = Adam(params, **self.optimizer_config)
-    
+
+    @property
+    def supports_memory_efficient_fp16(self):
+        return self._optimizer.supports_memory_efficient_fp16
+
     @property
     def optimizer_config(self):
         """

--- a/fairseq_signals/tasks/ecg_classification.py
+++ b/fairseq_signals/tasks/ecg_classification.py
@@ -87,7 +87,8 @@ class ECGDiagnosisTask(ECGPretrainingTask):
                 leads_bucket=self.cfg.leads_bucket,
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in split else False,
-                **self._get_mask_precompute_kwargs(task_cfg)
+                **self._get_mask_precompute_kwargs(task_cfg),
+                **kwargs,
             )
         else:
             self.datasets[split] = PathECGDataset(
@@ -110,5 +111,6 @@ class ECGDiagnosisTask(ECGPretrainingTask):
                 leads_bucket=self.cfg.leads_bucket,
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in split else False,
-                **self._get_mask_precompute_kwargs(task_cfg)
+                **self._get_mask_precompute_kwargs(task_cfg),
+                **kwargs,
             )

--- a/fairseq_signals/tasks/ecg_identification.py
+++ b/fairseq_signals/tasks/ecg_identification.py
@@ -111,6 +111,7 @@ class ECGIdentificationTask(ECGPretrainingTask):
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in s else False,
                 **self._get_mask_precompute_kwargs(task_cfg),
+                **kwargs,
             )
 
     def get_gallery_iterator(

--- a/fairseq_signals/tasks/ecg_pretraining.py
+++ b/fairseq_signals/tasks/ecg_pretraining.py
@@ -277,7 +277,8 @@ class ECGPretrainingTask(Task):
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in split else False,
                 **self._get_mask_precompute_kwargs(task_cfg),
-                **self._get_perturbation_kwargs()
+                **self._get_perturbation_kwargs(),
+                **kwargs,
             )
         elif task_cfg.criterion_name == '3kg':
             if task_cfg.leads_to_load is not None:
@@ -301,6 +302,7 @@ class ECGPretrainingTask(Task):
                 num_buckets=self.cfg.num_batch_buckets,
                 training=True if 'train' in split else False,
                 **inferred_3kg_config,
+                **kwargs,
             )
         elif task_cfg.criterion_name == 'simclr':
             self.datasets[split] = PerturbECGDataset(
@@ -322,7 +324,8 @@ class ECGPretrainingTask(Task):
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in split else False,
                 **self._get_mask_precompute_kwargs(task_cfg),
-                **self._get_perturbation_kwargs()
+                **self._get_perturbation_kwargs(),
+                **kwargs,
             )
         else:
             self.datasets[split] = FileECGDataset(
@@ -344,7 +347,8 @@ class ECGPretrainingTask(Task):
                 bucket_selection=self.cfg.bucket_selection,
                 training=True if 'train' in split else False,
                 **self._get_mask_precompute_kwargs(task_cfg),
-                **self._get_perturbation_kwargs()
+                **self._get_perturbation_kwargs(),
+                **kwargs,
             )
 
     def max_positions(self):

--- a/fairseq_signals/utils/store.py
+++ b/fairseq_signals/utils/store.py
@@ -374,21 +374,30 @@ def initialize_stores(
     subset,
     logits_shape,
     targets_shape,
+    directory=None,
 ):
     # Handle stores
     if (
         dist_utils.get_data_parallel_world_size() == 1
         or dist_utils.get_data_parallel_rank() == 0
     ):
+        logits_path = f'logits_{subset}.npy'
+        if directory is not None:
+            logits_path = os.path.join(directory, logits_path)
+
         criterion.set_output_store(MemmapBatchWriter(
-            f"logits_{subset}.npy",
+            logits_path,
             logits_shape,
             dtype=dtype,
             transform=lambda batch: batch.detach().cpu().numpy(),
         ))
 
+        targets_path = f'targets_{subset}.npy'
+        if directory is not None:
+            targets_path = os.path.join(directory, targets_path)
+
         criterion.set_target_store(MemmapBatchWriter(
-            f"targets_{subset}.npy",
+            targets_path,
             targets_shape,
             dtype=dtype,
             transform=lambda batch: batch.detach().cpu().numpy(),


### PR DESCRIPTION
Initialize stores with a save directory using common_eval.results_path argument.

Pass previously unused kwargs through the load_dataset functions of signal-based tasks.
- This makes it possible to set shuffle=False during validation of signal-based tasks.

Fix fp16 bug with Adam optimizer.