### PR TITLE
Bug fixes and preprocessing pipeline improvements.

### DIFF
--- a/examples/w2v_cmsc/config/finetuning/ecg_transformer/diagnosis.yaml
+++ b/examples/w2v_cmsc/config/finetuning/ecg_transformer/diagnosis.yaml
@@ -57,7 +57,7 @@ lr_scheduler:
 
 model:
   _name: ecg_transformer_classifier
-  model_path: ???
+  model_path: null
   num_labels: 26
   no_pretrained_weights: false
 

--- a/fairseq_signals/tasks/ecg_pretraining.py
+++ b/fairseq_signals/tasks/ecg_pretraining.py
@@ -364,11 +364,18 @@ class ECGPretrainingTask(Task):
     ):
         # we do not need to filter by size in this task as dataloaders take care of this
         return indices
-    
-    def valid_step(self, sample, model, criterion, subset=None):
-        loss, sample_size, logging_output = super().valid_step(sample, model, criterion, subset)
+
+    def valid_step(self, sample, model, criterion, subset=None, save_outputs=False):
+        loss, sample_size, logging_output = super().valid_step(
+            sample,
+            model,
+            criterion,
+            subset,
+            save_outputs=save_outputs,
+        )
+
         return loss, sample_size, logging_output
-    
+
     def build_model(self, model_cfg: Dataclass):
         model = super().build_model(model_cfg)
 

--- a/scripts/preprocess/ecg/README.md
+++ b/scripts/preprocess/ecg/README.md
@@ -2,13 +2,19 @@ This document outlines `fairseq-signals`' flexible, end-to-end, multi-source dat
 
 # Overview
 
-**The signal processing must be performed one dataset at a time** so as to appropriately create unique integer sample IDs and record them in the `manifest_file`. The sample IDs are useful for attributing labels to samples such that they do not need to be stored within the ECG waveform files themselves.
+**The signal processing must be performed one dataset at a time** so as to appropriately create unique integer sample IDs (`idx`) and record them in the `manifest_file`. The sample IDs are useful for attributing labels to samples such that they do not need to be stored within the ECG waveform files themselves. It is skillful to save copies of the `manifest_file` between processing datasets to avoid losing this information.
 
 The `*_records.py` scripts grab all relevant file paths, as well as any metadata which might already be stored in a tabular format (`records.csv`). This is helpful for compiling information available without loading any waveforms, as well as providing an opportunity to filter out select samples before processsing.
 
 The `*_signals.py` scripts extracts file metadata (`meta.csv`) and performs preprocessing, specifically converting the raw waveform into a `.mat` format (`org/`), performing operations such as resampling and standardization (`preprocessed/`), and finally segmenting the ECGs into non-overlapping portions of a desired length (`segmented/`).
 
 The `splits.py` script partitions the data, for example, into `train`, `valid`, and `test` sets which can be used for experimentation (`meta_split.csv`, `segmented_split.csv`). Multiple different strategies are available for use under this same script.
+
+The `*_labels.py` scripts extracts labels from the data and saves a CSV of label columns along with their sample IDs (`idx`). In the case of multilabel classification, it will contain multiple binary columns.
+
+The `prepare_clf_labels.py` script accepts files for the splits and labels to create a label definition containing label order, names, and metadata; a NumPy array which can be specified using `+task.label_file=$LABEL_DIR/y.npy`, and positive weights for positive sample re-weighting, as specified using `+criterion.pos_weight=$(cat $LABEL_DIR/pos_weight.txt)`. Note that the positive weights are split-specific and therefore labels should be processed separately for different splits. The `prepare_clf_labels_args.yaml` object is saved to help keep track of which labels correspond to which splits. If there are missing labels, specify the labeled splits save file(s) to save new splits which exclude unlabeled samples.
+
+The `manifests.py` script converts split files into a format which is digestable by the framework. More on this [here](#manifests).
 
 Here is an example of a resulting directory structure after running the scripts for PhysioNet 2021 and MIMIC-IV-ECG:
 ```
@@ -22,14 +28,21 @@ data
 │   │   segmented.csv
 │   │   segmented_split.csv
 │   │
+│   └───labels
+│   │   │   label_def.csv
+│   │   │   labels.csv
+│   │   │   pos_weight.txt
+│   │   │   prepare_clf_labels_args.yaml
+│   │   │   y.npy
+│   │
 │   └───org
 │   │   │   ...
 │   │
 │   └───preprocessed
-│   |   │   ...
+│   │   │   ...
 │   │
 │   └───segmented
-│   |   │   ...
+│   │   │   ...
 │   │
 └───mimic_iv_ecg
 │   │   meta.csv
@@ -38,14 +51,21 @@ data
 │   │   segmented.csv
 │   │   segmented_split.csv
 │   │
+│   └───labels
+│   │   │   label_def.csv
+│   │   │   labels.csv
+│   │   │   pos_weight.txt
+│   │   │   prepare_clf_labels_args.yaml
+│   │   │   y.npy
+│   │
 │   └───org
 │   │   │   ...
 │   │
 │   └───preprocessed
-│   |   │   ...
+│   │   │   ...
 │   │
 │   └───segmented
-│   |   │   ...
+│   │   │   ...
 ```
 
 # Usage
@@ -58,10 +78,11 @@ cd .../fairseq-signals/scripts/preprocess/ecg
 
 ## Datasets
 ### PhysioNet 2021
-Designed for and tested with PhysioNet 2021 v1.0.3. This data source stores its waveforms as WFDB files.
+Designed for and tested with [PhysioNet 2021 v1.0.3](https://physionet.org/content/challenge-2021/1.0.3/) and its [evaluation code](https://github.com/physionetchallenges/evaluation-2021). This data source stores its waveforms as WFDB files.
 
 ```
 PHYSIONET_ROOT=".../physionet.org/files/challenge-2021/1.0.3/training"
+EVALUATION_ROOT=".../evaluation-2021"
 
 python physionet2021_records.py \
     --processed_root "$PROCESSED_ROOT/physionet2021" \
@@ -79,10 +100,21 @@ python ../splits.py \
     --processed_root "$PROCESSED_ROOT/physionet2021" \
     --filter_cols "nan_any,constant_leads_any" \
     --dataset_subset "cpsc_2018, cpsc_2018_extra, georgia, ptb-xl, chapman_shaoxing, ningbo" # Excludes 'ptb' and 'st_petersburg_incart'
+
+mkdir $PROCESSED_ROOT/physionet2021/labels
+python physionet2021_labels.py \
+    --processed_root "$PROCESSED_ROOT/physionet2021" \
+    --weights_path "$EVALUATION_ROOT/weights.csv" \
+    --weight_abbrev_path "$EVALUATION_ROOT/weights_abbreviations.csv" \
+
+python prepare_clf_labels.py \
+    --output_dir "$PROCESSED_ROOT/physionet2021/labels"
+    --labels "$PROCESSED_ROOT/physionet2021/labels/labels.csv"
+    --meta_splits "$PROCESSED_ROOT/physionet2021/meta_split.csv"
 ```
 
 ### MIMIC-IV-ECG
-Designed for and tested with MIMIC-IV-ECG v1.0 (and optionally MIMIC-IV v2.2). This data source stores its waveforms as WFDB files.
+Designed for and tested with [MIMIC-IV-ECG v1.0](https://physionet.org/content/mimic-iv-ecg/1.0/) (and optionally [MIMIC-IV v2.2](https://physionet.org/content/mimiciv/2.2/)). This data source stores its waveforms as WFDB files.
 
 ```
 MIMIC_IV_ECG_ROOT=".../MIMIC-IV-ECG"
@@ -108,11 +140,11 @@ python ../splits.py \
 ```
 
 ### CODE-15%
-Designed for and tested with CODE-15% Version 1.0.0 (https://zenodo.org/records/4916206). This data source stores its waveforms in an HDF5 file.
+Designed for and tested with [CODE-15% Version 1.0.0](https://zenodo.org/records/4916206/). This data source stores its waveforms in an HDF5 file.
 ```
 CODE_15_ROOT=".../code_15"
 
-# There is no need for a code_15_records.py file
+# No need for a code_15_records.py script
 # Simply rename exams.csv to records.csv and place it in the processed root
 
 python code_15_signals.py --help
@@ -127,12 +159,8 @@ python code_15_signals.py \
 There are also scripts for extracting MUSE v8.0.2.10132 XML ECGs, however, the generalizability of this code is unclear at this time. This data source stores its waveforms as XML files.
 
 
-## Manifest Creation
-The `manifests.py` script converts split files into a directory of e.g., `train.tsv`, `valid.tsv`, `test.tsv`
-
-save directory can be specified in the framework using the `--task.data` argument
-
- which can be specified to `fairseq-signals`. This is not to be confused with the `manifest.csv`
+## Manifests
+The `manifests.py` script converts split files into a directory of separate files e.g., `train.tsv`, `valid.tsv`, `test.tsv`. This save directory can then be specified in the framework using the `--task.data` argument. While task-specific manifests typically consist of one dataset, multiple paths may be specified in `split_file_paths` to combine multiple datasets for pretraining purposes.
 
 ```
 MANIFEST_DIR = "$PROCESSED_ROOT/manifests/..."
@@ -143,27 +171,16 @@ python manifests.py \
     --split_file_paths "$PROCESSED_ROOT/physionet2021/segmented_split.csv,$PROCESSED_ROOT/mimic_iv_ecg/segmented_split.csv" \
     --save_dir "$MANIFEST_DIR"
 
-# If training a CMSC model
+# If training a CMSC model, the manifest must be converted accordingly
 python .../fairseq_signals/data/ecg/preprocess/convert_to_cmsc_manifest.py \
     "$MANIFEST_DIR" \
     --dest "$MANIFEST_DIR"
 ```
 
-## Binary Classification
-
-Prepares a CSV of binary columns for classification, creating a NumPy array, label definition, and positive weights for positive sample re-weighting.
-
-```
-python prepare_clf_labels.py \
-    --output_dir "$PROCESSED_ROOT/physionet2021/labels"
-    --labels "$PROCESSED_ROOT/physionet2021/labels/labels.csv"
-    --splits "$PROCESSED_ROOT/physionet2021/segmented_split.csv"
-```
-
 # Curating Datasets
 
-To curate a dataset, new `*_records.py` and `*_signals.py` files must be created. The `example_records.py` and `example_signals.py` files provide useful documentation, outlining the structure to follow when curating a new dataset.
+To curate a dataset, new `*_records.py` and `*_signals.py` files must be created. The `example_records.py` and `example_signals.py` files provide useful documentation, outlining the general structure to follow when curating a new dataset.
 
 A `*_records.py` file may not be required if a dataset already has a CSV of records, or it may be as simple as loading this file and renaming certain columns. The only requirement is a `path` column in the resulting `records.csv`, which is used by the `extract_func` defined in the corresponding `*_signals.py` file.
 
-A `*_signals.py` file is required, however, there may be code available to help load the new dataset signals. For example, the `extract_wfdb` function used by both the PhysioNet 2021 and MIMIC-IV-ECG datasets.
+A `*_signals.py` file is required to process the waveforms, however, the existing solutions may work for new datasets, for example, the `extract_wfdb` function being used by both the PhysioNet 2021 and MIMIC-IV-ECG datasets.

--- a/scripts/preprocess/ecg/physionet2021_labels.py
+++ b/scripts/preprocess/ecg/physionet2021_labels.py
@@ -37,7 +37,8 @@ def get_parser():
         "--labels_path",
         type=str,
         default=None,
-        help="Path to save resultant labels file. Defaults to '{processed_root}/labels.csv'.",
+        help="Path to save resultant labels file. Defaults to "
+            "'{processed_root}/labels/labels.csv'.",
     )
     parser.add_argument(
         "--uncombined",
@@ -102,7 +103,7 @@ def main(args):
     )
 
     if args.labels_path is None:
-        labels_path = os.path.join(args.processed_root, 'labels.csv')
+        labels_path = os.path.join(args.processed_root, 'labels', 'labels.csv')
     else:
         labels_path = args.labels_path
 

--- a/scripts/preprocess/prepare_clf_labels.py
+++ b/scripts/preprocess/prepare_clf_labels.py
@@ -9,45 +9,80 @@ import pandas as pd
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--output_dir",
+        '--output_dir',
         type=str,
         required=True,
-        help="Path to output directory.",
+        help='Path to output directory.',
     )
     parser.add_argument(
-        "--labels",
+        '--labels',
         type=str,
         required=True,
         help="Path to a non-subsetted labels file which contains an 'idx' column.",
     )
     parser.add_argument(
-        "--splits",
+        '--meta_splits',
         type=str,
         required=True,
-        help="Path to splits file which contains 'idx' and 'split' columns. "
-            "The sample IDs in the labels must be a superset of those in the splits.",
+        help="Path to meta splits file which containing 'idx' and 'split' columns. ",
+    )
+    parser.add_argument(
+        '--segmented_splits',
+        type=str,
+        required=False,
+        help="Path to segmented splits file containing 'idx' and 'split' columns. ",
+    )
+    parser.add_argument(
+        '--labeled_meta_splits_save_file',
+        required=False,
+        type=str,
+        help='Path to save the meta splits data, as filtered to those '
+            'samples having labels. Useful for creating task-specific manifests.',
+    )
+    parser.add_argument(
+        '--labeled_segmented_splits_save_file',
+        required=False,
+        type=str,
+        help='Path to save the segmented splits data, as filtered to those '
+            'samples having labels. Useful for creating task-specific manifests.',
     )
 
     return parser
 
 def main(args):
+    if args.labeled_segmented_splits_save_file is not None:
+        if args.segmented_splits is None:
+            raise ValueError(
+                'Must specify `segmented_splits` when '
+                '`labeled_segmented_splits_save_file` is specified.'
+            )
+
     labels = pd.read_csv(args.labels, index_col='idx').sort_index()
     label_names = list(labels.columns)
 
-    if not (labels.index == np.arange(labels.index.min(), labels.index.max() + 1)).all():
-        raise ValueError('Expected contiguous sample IDs (idx).')
-
     if not labels.index.is_unique:
-        raise ValueError('Expected unique sample IDs (idx).')
+        raise ValueError('Expected unique sample IDs (idx) in labels.')
 
-    splits = pd.read_csv(args.splits, index_col='idx')
+    meta_splits = pd.read_csv(args.meta_splits, index_col='idx')
 
-    # Get those labels being used in the splits
-    splits = splits.join(labels, how='left')
+    # Create label array
+    y = np.zeros((max([labels.index.max(), meta_splits.index.max()]) + 1, len(label_names)))
+    np.put_along_axis(y, labels.index.values.reshape(-1, 1), labels.values, 0)
+
+    # When calculating label metadata, use only those labeled samples in the splits
+    meta_splits = meta_splits.join(labels, how='left')
+    label_missing = meta_splits[label_names].isna().any(axis=1)
+    if label_missing.any():
+        print(
+            'Filling unlabelled samples in y.npy with zeros. Ensure that these samples do not '
+            'appear in the manifest by specifying and using the labeled save files.'
+        )
+
+    meta_splits = meta_splits[~label_missing].copy()
 
     # Create label definition
-    label_counts = splits[label_names + ['split']].groupby('split').sum()
-    label_percents = label_counts.div(splits['split'].value_counts(), axis=0)
+    label_counts = meta_splits[label_names + ['split']].groupby('split').sum()
+    label_percents = label_counts.div(meta_splits['split'].value_counts(), axis=0)
     label_counts = label_counts.T.add_prefix('pos_count_')
 
     label_weights = (1 - label_percents)/label_percents
@@ -60,13 +95,8 @@ def main(args):
     ], axis=1)
     label_def.index.name = 'name'
 
-    label_def['pos_count_all'] = splits[label_names].sum(axis=0)
-    label_def['pos_percent_all'] = label_def['pos_count_all'] / len(splits)
-
-    # Extract and pad labels
-    y = labels.values.astype(float)
-    y_empty = np.zeros((labels.index.min(), y.shape[1]), dtype=y.dtype)
-    y = np.concatenate([y_empty, y])
+    label_def['pos_count_all'] = meta_splits[label_names].sum(axis=0)
+    label_def['pos_percent_all'] = label_def['pos_count_all'] / len(meta_splits)
 
     # Save the label definition
     label_def.to_csv(os.path.join(args.output_dir, 'label_def.csv'))
@@ -84,7 +114,18 @@ def main(args):
     with open(os.path.join(args.output_dir, 'prepare_clf_labels_args.yaml'), 'w') as file:
         yaml.dump(args, file)
 
-if __name__ == "__main__":
+    if args.labeled_meta_splits_save_file is not None:
+        meta_splits.drop(label_names, axis=1, inplace=True)
+        meta_splits.to_csv(args.labeled_meta_splits_save_file)
+
+    if args.labeled_segmented_splits_save_file is not None:
+        segmented_splits = pd.read_csv(args.segmented_splits, index_col='idx')
+        segmented_splits = segmented_splits[
+            segmented_splits.index.isin(meta_splits.index)
+        ].copy()
+        segmented_splits.to_csv(args.labeled_segmented_splits_save_file)
+
+if __name__ == '__main__':
     parser = get_parser()
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
- Updated prepare_clf_labels.py to support missing labels, saving new split files with only labeled samples.
- Updated and improved preprocessing pipeline documentation.
- Made model_path optional for ECG transformer classifier, adding support for when `no_pretrained_weights` is set to True.
- Fixed bug of missing save_outputs argument in ECG pretraining.