### PR TITLE
Enabled `fairseq_signals.models.build_model` to load model weights when setting `from_checkpoint=True` and `checkpoint_path` is given.

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -116,7 +116,7 @@ def main(cfg: Config) -> None:
         else:
             for valid_sub_split in cfg.dataset.valid_subset.split(","):
                 task.load_dataset(valid_sub_split, combine = False, epoch = 1)
-    
+
     # Build trainer
     trainer = Trainer(cfg, task, model, criterion)
 
@@ -132,7 +132,6 @@ def main(cfg: Config) -> None:
         )
     )
 
-
     # Load the latest checkpoint if one is available and restore the
     # corresponding train iterator
     extra_state, epoch_itr = checkpoint_utils.load_checkpoint(
@@ -141,7 +140,7 @@ def main(cfg: Config) -> None:
         # don't cache epoch iterators for sharded datasets
         disable_iterator_cache = task.has_sharded_data("train")
     )
-    
+
     max_epoch = cfg.optimization.max_epoch or math.inf
     lr = trainer.get_lr()
 

--- a/fairseq_signals/trainer.py
+++ b/fairseq_signals/trainer.py
@@ -331,7 +331,7 @@ class Trainer(object):
             # load model parameters
             try:
                 self.model.load_state_dict(
-                    state["model"], strict=True, model_cfg = self.cfg.model
+                    state["model"], strict=True, model_cfg=self.cfg.model
                 )
                 # save memory for later steps
                 del state["model"]
@@ -340,7 +340,7 @@ class Trainer(object):
                         state["criterion"], strict=True
                     )
                     del state["criterion"]
-            
+
             except Exception:
                 raise Exception(
                     "Cannot load model parameters from checkpoint {};"


### PR DESCRIPTION
Fixed #34 